### PR TITLE
Draft Relevance / Custom Score Queries

### DIFF
--- a/src/Examine.Core/Clock.cs
+++ b/src/Examine.Core/Clock.cs
@@ -1,0 +1,16 @@
+using System;
+
+namespace Examine
+{
+    /// <summary>
+    /// Examine Clock
+    /// </summary>
+    public static class ExamineClock
+    {
+        /// <summary>
+        /// Gets the current time.
+        /// </summary>
+        /// <remarks>By default, this is UTC</remarks>
+        public static Func<DateTimeOffset> CurrentTime { get; set; } = () => DateTimeOffset.UtcNow;
+    }
+}

--- a/src/Examine.Core/ReadOnlyRelevanceScorerDefinitionCollection.cs
+++ b/src/Examine.Core/ReadOnlyRelevanceScorerDefinitionCollection.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Examine
+{
+    public class ReadOnlyRelevanceScorerDefinitionCollection : IEnumerable<RelevanceScorerDefinition>
+    {
+        public ReadOnlyRelevanceScorerDefinitionCollection()
+            : this(Enumerable.Empty<RelevanceScorerDefinition>())
+        {
+        }
+
+        public ReadOnlyRelevanceScorerDefinitionCollection(params RelevanceScorerDefinition[] definitions)
+            : this((IEnumerable<RelevanceScorerDefinition>)definitions)
+        {
+
+        }
+
+        public ReadOnlyRelevanceScorerDefinitionCollection(IEnumerable<RelevanceScorerDefinition> definitions)
+        {
+            if (definitions == null)
+                return;
+
+            foreach (var s in definitions.GroupBy(x => x.Name))
+            {
+                var suggester = s.FirstOrDefault();
+                if (suggester != default)
+                {
+                    Definitions.TryAdd(s.Key, suggester);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Tries to get a <see cref="RelevanceScorerDefinition"/> by name
+        /// </summary>
+        /// <param name="relevanceScorerName"></param>
+        /// <param name="relevanceScorerDefinition"></param>
+        /// <returns>
+        /// returns true if one was found otherwise false
+        /// </returns>
+        /// <remarks>
+        /// Marked as virtual so developers can inherit this class and override this method in case
+        /// relevance definitions are dynamic.
+        /// </remarks>
+        public virtual bool TryGetValue(string relevanceScorerName, out RelevanceScorerDefinition relevanceScorerDefinition) => Definitions.TryGetValue(relevanceScorerName, out relevanceScorerDefinition);
+
+        public int Count => Definitions.Count;
+
+        protected ConcurrentDictionary<string, RelevanceScorerDefinition> Definitions { get; } = new ConcurrentDictionary<string, RelevanceScorerDefinition>(StringComparer.InvariantCultureIgnoreCase);
+
+        public IEnumerator<RelevanceScorerDefinition> GetEnumerator() => Definitions.Values.GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+}

--- a/src/Examine.Core/RelevanceScorerDefinition.cs
+++ b/src/Examine.Core/RelevanceScorerDefinition.cs
@@ -1,0 +1,34 @@
+using System.Collections.Generic;
+
+namespace Examine
+{
+    /// <summary>
+    /// Defines how to score a document to affect it's relevance
+    /// </summary>
+    public class RelevanceScorerDefinition
+    {
+        public RelevanceScorerDefinition(string name,
+                                         IEnumerable<RelevanceScorerParameterDefinition> parameterDefinitions,
+                                         IEnumerable<RelevanceScorerFunctionBaseDefintion> functionScorerDefintions)
+        {
+            Name = name;
+            ParameterDefinitions = parameterDefinitions;
+            FunctionScorerDefintions = functionScorerDefintions;
+        }
+
+        /// <summary>
+        /// Name
+        /// </summary>
+        public string Name { get; }
+
+        /// <summary>
+        /// Parameter Definitions
+        /// </summary>
+        public IEnumerable<RelevanceScorerParameterDefinition> ParameterDefinitions { get; }
+
+        /// <summary>
+        /// Field Boosting Function Defintions
+        /// </summary>
+        public IEnumerable<RelevanceScorerFunctionBaseDefintion> FunctionScorerDefintions { get; }
+    }
+}

--- a/src/Examine.Core/RelevanceScorerDefinitionCollection.cs
+++ b/src/Examine.Core/RelevanceScorerDefinitionCollection.cs
@@ -1,0 +1,25 @@
+using System;
+
+namespace Examine
+{
+    public class RelevanceScorerDefinitionCollection : ReadOnlyRelevanceScorerDefinitionCollection
+    {
+        public RelevanceScorerDefinitionCollection(params RelevanceScorerDefinition[] definitions) : base(definitions)
+        {
+        }
+
+        public RelevanceScorerDefinitionCollection()
+        {
+        }
+
+        public RelevanceScorerDefinition GetOrAdd(string fieldName, Func<string, RelevanceScorerDefinition> add) => Definitions.GetOrAdd(fieldName, add);
+
+        /// <summary>
+        /// Replace any definition with the specified one, if one doesn't exist then it is added
+        /// </summary>
+        /// <param name="definition"></param>
+        public void AddOrUpdate(RelevanceScorerDefinition definition) => Definitions.AddOrUpdate(definition.Name, definition, (s, factory) => definition);
+
+        public bool TryAdd(RelevanceScorerDefinition definition) => Definitions.TryAdd(definition.Name, definition);
+    }
+}

--- a/src/Examine.Core/RelevanceScorerFunctionBaseDefintion.cs
+++ b/src/Examine.Core/RelevanceScorerFunctionBaseDefintion.cs
@@ -1,0 +1,36 @@
+﻿namespace Examine
+{
+    /// <summary>
+    /// Base for Relevance Scorer Functions
+    /// </summary>
+    public abstract class RelevanceScorerFunctionBaseDefintion
+    {
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="functionName">Name of the type of function</param>
+        /// <param name="fieldName">Name of the field for the function</param>
+        /// <param name="boost">Boost for the function</param>
+        public RelevanceScorerFunctionBaseDefintion(string functionName, string fieldName, float boost)
+        {
+            FunctionName = functionName;
+            FieldName = fieldName;
+            Boost = boost;
+        }
+
+        /// <summary>
+        /// Name of the type of function
+        /// </summary>
+        public string FunctionName { get; }
+
+        /// <summary>
+        /// Name of the field for the function
+        /// </summary>
+        public string FieldName { get; }
+
+        /// <summary>
+        /// Boost for the function
+        /// </summary>
+        public float Boost { get; }
+    }
+}

--- a/src/Examine.Core/RelevanceScorerParameterDefinition.cs
+++ b/src/Examine.Core/RelevanceScorerParameterDefinition.cs
@@ -1,0 +1,18 @@
+﻿namespace Examine
+{
+    /// <summary>
+    /// Defines a parameter for a Relevance Scorer
+    /// </summary>
+    public class RelevanceScorerParameterDefinition
+    {
+        public RelevanceScorerParameterDefinition(string name)
+        {
+            Name = name;
+        }
+
+        /// <summary>
+        /// Name
+        /// </summary>
+        public string Name { get; }
+    }
+}

--- a/src/Examine.Core/Scoring/FieldRelevanceScorerFunctionDefintion.cs
+++ b/src/Examine.Core/Scoring/FieldRelevanceScorerFunctionDefintion.cs
@@ -1,0 +1,18 @@
+
+namespace Examine.Scoring
+{
+    /// <summary>
+    /// Boosts a field
+    /// </summary>
+    public class FieldRelevanceScorerFunctionDefintion : RelevanceScorerFunctionBaseDefintion
+    {
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="fieldName">Name of the field</param>
+        /// <param name="boost">Boost</param>
+        public FieldRelevanceScorerFunctionDefintion(string fieldName, float boost) : base("Examine.Field", fieldName, boost)
+        {
+        }
+    }
+}

--- a/src/Examine.Core/Scoring/JavaScriptFunctionScorerFunctionDefinition.cs
+++ b/src/Examine.Core/Scoring/JavaScriptFunctionScorerFunctionDefinition.cs
@@ -1,0 +1,33 @@
+using System.Collections.Generic;
+
+namespace Examine.Scoring
+{
+    /// <summary>
+    /// Boosts relevance based on a JavaScript function
+    /// </summary>
+    public class JavaScriptFunctionScorerFunctionDefinition : RelevanceScorerFunctionBaseDefintion
+    {
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="fieldName">Name of the field</param>
+        /// <param name="boost">Boost</param>
+        /// <param name="javaScriptFunction">JavaScript Function</param>
+        /// <param name="parameterMap">Map from Relevance parameter name to JavaScript parameter name</param>
+        public JavaScriptFunctionScorerFunctionDefinition(string fieldName, float boost, string javaScriptFunction, IReadOnlyDictionary<string,string> parameterMap) : base("Examine.JavaScript", fieldName, boost)
+        {
+            JavaScriptFunction = javaScriptFunction;
+            ParameterMap = parameterMap;
+        }
+
+        /// <summary>
+        /// JavaScript Function
+        /// </summary>
+        public string JavaScriptFunction { get; }
+
+        /// <summary>
+        /// Map Relevance Parameter name to JavaScript function parameter name
+        /// </summary>
+        public IReadOnlyDictionary<string, string> ParameterMap { get; }
+    }
+}

--- a/src/Examine.Core/Scoring/NumericRangeRelevanceScorerFunctionDefintion.cs
+++ b/src/Examine.Core/Scoring/NumericRangeRelevanceScorerFunctionDefintion.cs
@@ -1,0 +1,29 @@
+namespace Examine.Scoring
+{
+    /// <summary>
+    /// Boosts a range of numeric values
+    /// </summary>
+    public class NumericRangeRelevanceScorerFunctionDefintion : RelevanceScorerFunctionBaseDefintion
+    {
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="fieldName">Name of the field</param>
+        /// <param name="boost">Boost</param>
+        public NumericRangeRelevanceScorerFunctionDefintion(string fieldName, float boost, int boostRangeStart, int boostRangeEnd) : base("Examine.NumericRange", fieldName, boost)
+        {
+            BoostRangeStart = boostRangeStart;
+            BoostRangeEnd = boostRangeEnd;
+        }
+
+        /// <summary>
+        /// Lower bound of the range of values to boost
+        /// </summary>
+        public int BoostRangeStart { get; }
+
+        /// <summary>
+        /// Upper bound of the range of values to boost
+        /// </summary>
+        public int BoostRangeEnd { get; }
+    }
+}

--- a/src/Examine.Core/Scoring/StringValuesRelevanceScorerFunctionDefintion.cs
+++ b/src/Examine.Core/Scoring/StringValuesRelevanceScorerFunctionDefintion.cs
@@ -1,0 +1,24 @@
+
+namespace Examine.Scoring
+{
+    /// <summary>
+    /// Boosts based on strings matching values in field
+    /// </summary>
+    public class StringValuesRelevanceScorerFunctionDefintion : RelevanceScorerFunctionBaseDefintion
+    {
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="fieldName">Name of the field</param>
+        /// <param name="boost">Boost</param>
+        public StringValuesRelevanceScorerFunctionDefintion(string fieldName, float boost, string stringsRelevanceParameterName) : base("Examine.NumericRange", fieldName, boost)
+        {
+            StringsRelevanceParameterName = stringsRelevanceParameterName;
+        }
+
+        /// <summary>
+        /// The name of the relevance parameter that contains a comma seperated list of strings to match on
+        /// </summary>
+        public string StringsRelevanceParameterName { get; }
+    }
+}

--- a/src/Examine.Core/Scoring/TimeRelevanceScorerFunctionDefintion.cs
+++ b/src/Examine.Core/Scoring/TimeRelevanceScorerFunctionDefintion.cs
@@ -1,0 +1,32 @@
+using System;
+
+namespace Examine.Scoring
+{
+    /// <summary>
+    /// Boosts relevance based on time recency
+    /// </summary>
+    public class TimeRelevanceScorerFunctionDefintion : RelevanceScorerFunctionBaseDefintion
+    {
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="fieldName">Name of the field</param>
+        /// <param name="boost">Boost</param>
+        /// <param name="boostTimeRange">Duration from current time to boost from <see cref="ExamineClock.CurrentTime"/></param>
+        public TimeRelevanceScorerFunctionDefintion(string fieldName, float boost, TimeSpan boostTimeRange, string startTimeParameterName = null) : base("Examine.Recency", fieldName, boost)
+        {
+            BoostTimeRange = boostTimeRange;
+            StartTimeParameterName = startTimeParameterName;
+        }
+
+        /// <summary>
+        /// Time range to boost from 
+        /// </summary>
+        public TimeSpan BoostTimeRange { get; }
+
+        /// <summary>
+        /// Name of parameter containing start time of range. If not set, uses <see cref="ExamineClock.CurrentTime"/>
+        /// </summary>
+        public string StartTimeParameterName { get; }
+    }
+}


### PR DESCRIPTION
Draft for implementing custom score queries. So far this covers how to define the parameters for a Relevance Scorer Function, and  add them to the index definition. The next step was to add to IQuery a way to add a CustomRelevanceScorerQuery that took the name of the defined Relevance Scorer Function, and any parameters necessary.